### PR TITLE
Fix auth cookies persistence

### DIFF
--- a/backend/middleware/authMiddleware.ts
+++ b/backend/middleware/authMiddleware.ts
@@ -19,12 +19,27 @@ export class AuthMiddleware {
   static authenticate = (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const authHeader = req.headers.authorization;
+      let token: string | undefined;
 
-      if (!authHeader?.startsWith('Bearer ')) {
+      if (authHeader?.startsWith('Bearer ')) {
+        token = authHeader.split(' ')[1];
+      } else {
+        const cookieHeader = req.headers.cookie;
+        if (cookieHeader) {
+          const cookies = cookieHeader.split(';').map(c => c.trim());
+          for (const cookie of cookies) {
+            if (cookie.startsWith('accessToken=')) {
+              token = cookie.substring('accessToken='.length);
+              break;
+            }
+          }
+        }
+      }
+
+      if (!token) {
         return res.status(401).json({ message: 'No token provided' });
       }
 
-      const token = authHeader.split(' ')[1];
       const decoded = TokenUtility.verifyAccessToken(token);
       
       req.user = decoded;

--- a/backend/routes/authRoutes.ts
+++ b/backend/routes/authRoutes.ts
@@ -30,16 +30,7 @@ router.post(
   '/login',
   AuthMiddleware.loginLimiter,
   AuthMiddleware.validateRequest(LoginDTO),
-  async (req, res) => {
-    try {
-      const { email, password } = req.body;
-      const result = await authService.login(email, password);
-      res.status(200).json(result);
-    } catch (error: any) {
-      logger.error('Login error:', error);
-      res.status(401).json({ message: error.message });
-    }
-  }
+  AuthController.login
 );
 
 // Refresh token

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
-import { loginUser, registerUser, logoutUser } from '../services/authService';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { loginUser, registerUser, logoutUser, fetchCurrentUser } from '../services/authService';
 
 interface User {
   id: string;
@@ -22,6 +22,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadUser = async () => {
+      try {
+        setIsLoading(true);
+        const response = await fetchCurrentUser();
+        setUser(response.user);
+      } catch (err) {
+        setUser(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadUser();
+  }, []);
 
   const login = async (email: string, password: string) => {
     try {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -45,4 +45,13 @@ export const logoutUser = async (): Promise<void> => {
     console.error('Logout failed:', error);
     throw error;
   }
-}; 
+};
+
+export const fetchCurrentUser = async (): Promise<AuthResponse> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/api/auth/profile`);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- read auth token from cookies and use cookie-based login on backend
- fetch current user from `/api/auth/profile` when React app loads

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa4b7a3d083338be764c456fc26c2